### PR TITLE
Fix comment, bug and add basic tests

### DIFF
--- a/GenPrompt_1_0/genprompt.zsh
+++ b/GenPrompt_1_0/genprompt.zsh
@@ -5,7 +5,7 @@
 # Author: You (powered by ChatGPT)
 # ──────────────────────────────────────────────
 
-set -euo pipefail
+setopt errexit nounset pipefail
 
 # Paths
 GENPROMPT_HOME=${GENPROMPT_HOME:-"$HOME/GenPrompt_1_0"}
@@ -44,7 +44,16 @@ load_bank() {
   done < "$BANK_DIR/${name}.txt"
 }
 
+# Load prompt banks
 for cat in $categories; do load_bank "$cat"; done
+
+# Helpers for English articles (a/an)
+article_for() {
+  [[ "$1" =~ ^[aeiouAEIOU] ]] && echo "an" || echo "a"
+}
+
+# Skip further setup when running tests
+[[ -n "$GENPROMPT_TESTING" ]] && { return 0 2>/dev/null || exit 0; }
 
 # Interactive picker — no Bash features, all Zsh
 pick() {
@@ -54,7 +63,7 @@ pick() {
   echo "\n\033[1mSelect $cat:\033[0m"
   echo "0)  (custom $cat)"
   for i in {1..${#opts[@]}}; do
-    printf '%-3d %s  —  %s\n' "$i)" "${opts[$i]}" "${desc[$i]}"
+    printf '%-3s %s  —  %s\n' "$i)" "${opts[$i]}" "${desc[$i]}"
   done
   while true; do
     printf "Choice [0-%d]: " "${#opts[@]}"
@@ -84,11 +93,6 @@ mood=$(pick moods)
 style=$(pick styles)
 shot=$(pick shots)
 movement=$(pick movements)
-
-# Helpers for English articles (a/an)
-article_for() {
-  [[ "$1" =~ ^[aeiouAEIOU] ]] && echo "an" || echo "a"
-}
 
 # Grammar: subject/setting phrases
 subject_phrase=$subject
@@ -176,4 +180,4 @@ log_file="$LOG_DIR/$(date +%F).log"
 print -P "%F{240}🗄  Logged to $log_file%f"
 
 # Placeholder for modcheck integration
-# Uncomment below to enable moderation lo
+# Uncomment below to enable moderation logging

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # string-white-lights
 Forever walking through December...
+
+## Running Tests
+
+This project uses [Bats](https://bats-core.readthedocs.io/) for testing. After
+installing `bats`, run the test suite with:
+
+```bash
+bats tests
+```

--- a/tests/article_for.bats
+++ b/tests/article_for.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+setup() {
+  script_dir="$(dirname "$BATS_TEST_DIRNAME")"
+  export GENPROMPT_HOME="$BATS_TEST_TMPDIR/home"
+  mkdir -p "$GENPROMPT_HOME/prompt_banks" "$GENPROMPT_HOME/prompt_logs"
+  for f in subjects actions settings times moods styles shots movements; do
+    touch "$GENPROMPT_HOME/prompt_banks/$f.txt"
+  done
+}
+
+@test "article_for handles words starting with vowel" {
+  run zsh -c 'export GENPROMPT_TESTING=1; source "$1"; article_for apple' _ "$script_dir/GenPrompt_1_0/genprompt.zsh"
+  [ "$status" -eq 0 ]
+  [ "$output" = "an" ]
+}
+
+@test "article_for handles words starting with consonant" {
+  run zsh -c 'export GENPROMPT_TESTING=1; source "$1"; article_for car' _ "$script_dir/GenPrompt_1_0/genprompt.zsh"
+  [ "$status" -eq 0 ]
+  [ "$output" = "a" ]
+}


### PR DESCRIPTION
## Summary
- improve portability by using `setopt` instead of bash `set`
- fix formatting of list output
- support sourcing for tests
- clarify comment text
- add Bats test for `article_for`
- document running tests

## Testing
- `bats tests`

------
https://chatgpt.com/codex/tasks/task_e_68830e0dd1308320b648a777bd64ecd5