### PR TITLE
Fix testing check in genprompt.zsh

### DIFF
--- a/GenPrompt_1_0/genprompt.zsh
+++ b/GenPrompt_1_0/genprompt.zsh
@@ -53,7 +53,7 @@ article_for() {
 }
 
 # Skip further setup when running tests
-[[ -n "$GENPROMPT_TESTING" ]] && { return 0 2>/dev/null || exit 0; }
+[[ -n ${GENPROMPT_TESTING:-} ]] && { return 0 2>/dev/null || exit 0; }
 
 # Interactive picker — no Bash features, all Zsh
 pick() {


### PR DESCRIPTION
## Summary
- fix environment variable check when GENPROMPT_TESTING is unset

## Testing
- `bats tests`

------
https://chatgpt.com/codex/tasks/task_e_68844f5464f883208b487a326572f8a5